### PR TITLE
Use newpipe.net instead of kernel.org for faulty stream source

### DIFF
--- a/test-app/src/main/java/net/newpipe/newplayer/testapp/TestMediaRepository.kt
+++ b/test-app/src/main/java/net/newpipe/newplayer/testapp/TestMediaRepository.kt
@@ -105,7 +105,7 @@ class TestMediaRepository(private val context: Context) : MediaRepository {
             "faulty" -> listOf(
                 Stream(
                     item = "faulty",
-                    streamUri = Uri.parse("https://kernel.org"),
+                    streamUri = Uri.parse("https://newpipe.net"),
                     mimeType = null,
                     streamTracks = listOf(
                         AudioStreamTrack(


### PR DESCRIPTION
The domain is not under our control, but newpipe.net is.