### PR TITLE
Use kotlin auto-derived equals

### DIFF
--- a/new-player/src/main/java/net/newpipe/newplayer/data/Stream.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/data/Stream.kt
@@ -68,14 +68,4 @@ data class Stream(
     val audioStreamTrack: List<AudioStreamTrack>
         get() = streamTracks.filterIsInstance<AudioStreamTrack>()
 
-    override fun equals(other: Any?) = other is Stream && other.hashCode() == this.hashCode()
-
-    override fun hashCode(): Int {
-        var result = item.hashCode()
-        result = 31 * result + streamUri.hashCode()
-        result = 31 * result + streamTracks.hashCode()
-        result = 31 * result + (mimeType?.hashCode() ?: 0)
-        return result
-    }
-
 }

--- a/new-player/src/main/java/net/newpipe/newplayer/data/StreamTrack.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/data/StreamTrack.kt
@@ -45,18 +45,6 @@ data class VideoStreamTrack(
 
     override fun toLongIdentifierString() = "$fileFormat ${toShortIdentifierString()}"
 
-    override fun equals(other: Any?) =
-        other is VideoStreamTrack
-                && other.hashCode() == this.hashCode()
-
-    override fun hashCode(): Int {
-        var result = width
-        result = 31 * result + height
-        result = 31 * result + frameRate
-        result = 31 * result + fileFormat.hashCode()
-        return result
-    }
-
     override fun compareTo(other: StreamTrack) =
         if (other is VideoStreamTrack) {
             val diff = width * height - other.width * other.height
@@ -100,17 +88,6 @@ data class AudioStreamTrack(
         } else {
             -1
         }
-
-    override fun equals(other: Any?) =
-        other is AudioStreamTrack
-                && other.hashCode() == this.hashCode()
-
-    override fun hashCode(): Int {
-        var result = bitrate
-        result = 31 * result + language.hashCode()
-        result = 31 * result + fileFormat.hashCode()
-        return result
-    }
 
     override fun toString() = """
         AudioStreamTrack {

--- a/new-player/src/main/java/net/newpipe/newplayer/data/VideoSize.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/data/VideoSize.kt
@@ -46,17 +46,6 @@ internal data class VideoSize(
 
     override fun compareTo(other: VideoSize) = width * height - other.width * other.height
 
-    override fun equals(other: Any?) =
-        when (other) {
-            is VideoSize ->
-                other.width == this.width && other.height == this.height && pixelWidthHeightRatio == other.pixelWidthHeightRatio
-
-            else -> false
-        }
-
-    override fun hashCode() =
-        width + height * 999999 + (pixelWidthHeightRatio*10000).toInt()
-
     fun getRatio() =
         (width * pixelWidthHeightRatio) / height
 

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/seeker/SeekerDefaults.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/seeker/SeekerDefaults.kt
@@ -209,7 +209,7 @@ internal interface SeekerDimensions {
 @Immutable
 
 /** @hide */
-internal class DefaultSeekerDimensions(
+internal data class DefaultSeekerDimensions(
     val trackHeight: Dp,
     val progressHeight: Dp,
     val gap: Dp,
@@ -234,36 +234,12 @@ internal class DefaultSeekerDimensions(
     override fun thumbRadius(): State<Dp> {
         return rememberUpdatedState(thumbRadius)
     }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as DefaultSeekerDimensions
-
-        if (trackHeight != other.trackHeight) return false
-        if (progressHeight != other.progressHeight) return false
-        if (gap != other.gap) return false
-        if (thumbRadius != other.thumbRadius) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = trackHeight.hashCode()
-
-        result = 31 * result + progressHeight.hashCode()
-        result = 31 * result + gap.hashCode()
-        result = 31 * result + thumbRadius.hashCode()
-
-        return result
-    }
 }
 
 @Immutable
 
 /** @hide */
-internal class DefaultSeekerColor(
+internal data class DefaultSeekerColor(
     val progressColor: Color,
     val trackColor: Color,
     val disabledTrackColor: Color,
@@ -298,35 +274,5 @@ internal class DefaultSeekerColor(
         return rememberUpdatedState(
             readAheadColor
         )
-    }
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other == null || this::class != other::class) return false
-
-        other as DefaultSeekerColor
-
-        if (progressColor != other.progressColor) return false
-        if (trackColor != other.trackColor) return false
-        if (disabledTrackColor != other.disabledTrackColor) return false
-        if (disabledProgressColor != other.disabledProgressColor) return false
-        if (thumbColor != other.thumbColor) return false
-        if (disabledThumbColor != other.disabledThumbColor) return false
-        if (readAheadColor != other.readAheadColor) return false
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = progressColor.hashCode()
-
-        result = 31 * result + trackColor.hashCode()
-        result = 31 * result + disabledTrackColor.hashCode()
-        result = 31 * result + disabledProgressColor.hashCode()
-        result = 31 * result + thumbColor.hashCode()
-        result = 31 * result + disabledThumbColor.hashCode()
-        result = 31 * result + readAheadColor.hashCode()
-
-        return result
     }
 }


### PR DESCRIPTION
Kotlin can derive `hashCode` and `equals` automatically, I assume these were a leftover from a time when the code was still in Java?

In case some fields should be ignored for equality, you could put them in the body of the class, but nothing here ignored any fields it looks like.