### PR TITLE
use findActivity everywhere

### DIFF
--- a/new-player/src/main/java/net/newpipe/newplayer/NewPlayerImpl.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/NewPlayerImpl.kt
@@ -298,10 +298,6 @@ class NewPlayerImpl(
                         mutableErrorFlow.emit(e)
                     }
                 }
-
-                else -> {
-                    throw NewPlayerException("Unknwon exception response ${response.javaClass}")
-                }
             }
         }
     }

--- a/new-player/src/main/java/net/newpipe/newplayer/logic/MediaSourceBuilder.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/logic/MediaSourceBuilder.kt
@@ -58,7 +58,7 @@ internal suspend fun buildMediaSource(
     ): MediaSource {
         when (streamSelection) {
             is SingleSelection -> {
-                val mediaItem = toMediaItem(streamSelection.item, streamSelection.stream, uniqueId)
+                val mediaItem = toMediaItem(streamSelection.stream, uniqueId)
                 val mediaItemWithMetadata = addMetadata(mediaItem, streamSelection.item)
                 return toMediaSource(mediaItemWithMetadata, streamSelection.stream)
             }
@@ -66,7 +66,6 @@ internal suspend fun buildMediaSource(
             is MultiSelection -> {
                 val mediaItems = ArrayList(streamSelection.streams.map {
                     toMediaItem(
-                        streamSelection.item,
                         it,
                         uniqueId
                     )
@@ -88,7 +87,7 @@ internal suspend fun buildMediaSource(
 
     @OptIn(UnstableApi::class)
     private
-    fun toMediaItem(item: String, stream: Stream, uniqueId: Long): MediaItem {
+    fun toMediaItem(stream: Stream, uniqueId: Long): MediaItem {
 
         val mediaItemBuilder = MediaItem.Builder()
             .setMediaId(uniqueId.toString())

--- a/new-player/src/main/java/net/newpipe/newplayer/logic/StreamExceptionResponse.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/logic/StreamExceptionResponse.kt
@@ -23,7 +23,7 @@ package net.newpipe.newplayer.logic;
 import net.newpipe.newplayer.data.StreamSelection
 import net.newpipe.newplayer.NewPlayer
 
-interface StreamExceptionResponse
+sealed interface StreamExceptionResponse
 
 /***
  * Perform a specific action, like halting the playback or etc.

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
@@ -145,9 +145,9 @@ fun NewPlayerUI(
             }
         }
 
+        val defaultBrightness = activity.getDefaultBrightness()
         LaunchedEffect(key1 = uiState.brightness) {
             Log.d(TAG, "New Brightness: ${uiState.brightness}")
-            val defaultBrightness = getDefaultBrightness(activity)
 
             setScreenBrightness(
                 uiState.brightness ?: defaultBrightness, activity

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui
 
-import android.app.Activity
 import android.content.pm.ActivityInfo
 import android.os.Build
 import android.util.Log
@@ -31,7 +30,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.view.WindowCompat
@@ -48,9 +46,12 @@ import net.newpipe.newplayer.ui.audioplayer.AudioPlayerUI
 import net.newpipe.newplayer.ui.theme.VideoPlayerTheme
 import net.newpipe.newplayer.ui.videoplayer.VideoPlayerUi
 import net.newpipe.newplayer.ui.common.LockScreenOrientation
+import net.newpipe.newplayer.ui.common.activity
+import net.newpipe.newplayer.ui.common.findActivity
 import net.newpipe.newplayer.ui.common.getDefaultBrightness
 import net.newpipe.newplayer.ui.common.isInPowerSaveMode
 import net.newpipe.newplayer.ui.common.setScreenBrightness
+import net.newpipe.newplayer.ui.common.window
 
 private const val TAG = "VideoPlayerUI"
 
@@ -84,9 +85,9 @@ fun NewPlayerUI(
     } else {
         val uiState by viewModel.uiState.collectAsState()
 
-        val activity = LocalContext.current as Activity
+        // find out whether application is light or dark mode from LocalContext.current
         val view = LocalView.current
-
+        val activity = activity()
         val window = activity.window
 
         // Setup fullscreen
@@ -145,7 +146,7 @@ fun NewPlayerUI(
         }
 
         LaunchedEffect(key1 = uiState.brightness) {
-            Log.d(TAG, "New Brightnes: ${uiState.brightness}")
+            Log.d(TAG, "New Brightness: ${uiState.brightness}")
             val defaultBrightness = getDefaultBrightness(activity)
 
             setScreenBrightness(

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/audioplayer/AudioPlayerEmbeddedUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/audioplayer/AudioPlayerEmbeddedUI.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui.audioplayer
 
-import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -37,14 +36,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.R
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -57,17 +54,14 @@ import net.newpipe.newplayer.ui.common.getEmbeddedUiConfig
 import net.newpipe.newplayer.ui.common.getLocale
 import net.newpipe.newplayer.ui.common.getTimeStringFromMs
 
-@OptIn(androidx.media3.common.util.UnstableApi::class)
+@OptIn(UnstableApi::class)
 @Composable
 
 /** @hide */
 internal fun AudioPlayerEmbeddedUI(viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIState) {
     val locale = getLocale()!!
 
-    val embeddedUIConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val embeddedUIConfig = getEmbeddedUiConfig()
 
     Box(modifier = Modifier.wrapContentSize()) {
         Thumbnail(

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/audioplayer/BottomUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/audioplayer/BottomUI.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui.audioplayer
 
-import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -36,7 +35,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PictureInPicture
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Speed
-import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material3.Button
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -56,7 +54,6 @@ import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.R
 import net.newpipe.newplayer.ui.common.LanguageMenu
 import net.newpipe.newplayer.ui.common.LanguageMenuItem
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -72,10 +69,7 @@ import net.newpipe.newplayer.ui.common.showNotYetImplementedToast
 /** @hide */
 internal fun AudioBottomUI(viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIState) {
 
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
     Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceBetween) {
         Row(
@@ -142,10 +136,7 @@ private fun Menu(viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIStat
     var showMenu: Boolean by remember { mutableStateOf(false) }
     var showLanguageMenu: Boolean by remember { mutableStateOf(false) }
 
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
     Box {
         IconButton(onClick = {

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/common/utils.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/common/utils.kt
@@ -27,6 +27,7 @@ import android.content.ContextWrapper
 import android.net.Uri
 import android.os.Build
 import android.os.PowerManager
+import android.view.Window
 import android.view.WindowManager
 import androidx.annotation.OptIn
 import androidx.annotation.RequiresApi
@@ -54,6 +55,21 @@ import net.newpipe.newplayer.data.NewPlayerException
 import net.newpipe.newplayer.R
 import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import java.util.Locale
+
+@Composable
+internal fun activity(): Activity
+    = LocalContext.current.findActivity()!!
+
+@Composable
+internal fun window(): Window
+    = activity().window
+
+/** @hide */
+internal fun Context.findActivity(): Activity? = when (this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
 
 @Composable
 
@@ -86,12 +102,6 @@ internal fun setScreenBrightness(value: Float, activity: Activity) {
 }
 
 
-/** @hide */
-internal fun Context.findActivity(): Activity? = when (this) {
-    is Activity -> this
-    is ContextWrapper -> baseContext.findActivity()
-    else -> null
-}
 
 
 @Composable

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/selection_ui/ChapterSelectUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/selection_ui/ChapterSelectUI.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui.selection_ui
 
-import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -34,11 +33,9 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -57,10 +54,7 @@ internal fun ChapterSelectUI(
 ) {
     val insets = getInsets()
 
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
     Scaffold(
         modifier = Modifier

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/selection_ui/StreamSelectTopBar.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/selection_ui/StreamSelectTopBar.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui.selection_ui
 
-import android.app.Activity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.PlaylistAdd
@@ -41,7 +40,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.R
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -65,11 +63,7 @@ internal fun StreamSelectTopBar(
     uiState: NewPlayerUIState
 ) {
 
-    val embeddedUiConfig =
-        if (LocalContext.current is Activity)
-            getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-        else
-            EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
     TopAppBar(modifier = modifier,
         colors = topAppBarColors(containerColor = Color.Transparent),

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/PlaySurface.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/PlaySurface.kt
@@ -60,9 +60,9 @@ internal fun PlaySurface(
 
     // Preparation
 
-    val activity = LocalContext.current as Activity
+    val ctx = LocalContext.current
 
-    val displayMetrics = activity.resources.displayMetrics
+    val displayMetrics = ctx.resources.displayMetrics
 
     val screenRatio =
         displayMetrics.widthPixels.toFloat() / displayMetrics.heightPixels.toFloat()

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/VideoPlayerUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/VideoPlayerUI.kt
@@ -52,6 +52,7 @@ import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.ui.selection_ui.StreamSelectUI
 import androidx.lifecycle.LifecycleEventObserver
 import net.newpipe.newplayer.data.NewPlayerException
+import net.newpipe.newplayer.ui.common.activity
 import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.ui.selection_ui.ChapterSelectUI
 import net.newpipe.newplayer.ui.videoplayer.pip.getPipParams
@@ -64,14 +65,12 @@ import net.newpipe.newplayer.uiModel.UIModeState
 
 /** @hide */
 internal fun VideoPlayerUi(viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIState) {
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val activity = activity()
+
+    getEmbeddedUiConfig(activity = LocalContext.current as Activity)
 
     val exoPlayer by viewModel.newPlayer?.exoPlayer!!.collectAsState()
 
-    val activity = LocalContext.current as Activity
 
     var videoViewBounds by remember {
         mutableStateOf(android.graphics.Rect())

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/VideoPlayerUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/VideoPlayerUI.kt
@@ -20,17 +20,14 @@
 
 package net.newpipe.newplayer.ui.videoplayer
 
-import android.app.Activity
 import android.os.Build
 import androidx.annotation.OptIn
-import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -43,21 +40,16 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toAndroidRectF
 import androidx.compose.ui.layout.boundsInWindow
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
 import androidx.core.graphics.toRect
-import androidx.lifecycle.Lifecycle
 import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.ui.selection_ui.StreamSelectUI
-import androidx.lifecycle.LifecycleEventObserver
 import net.newpipe.newplayer.data.NewPlayerException
 import net.newpipe.newplayer.ui.common.activity
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.ui.selection_ui.ChapterSelectUI
 import net.newpipe.newplayer.ui.videoplayer.pip.getPipParams
 import net.newpipe.newplayer.ui.videoplayer.pip.supportsPip
-import net.newpipe.newplayer.ui.common.getEmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.UIModeState
 
 @OptIn(UnstableApi::class)
@@ -66,8 +58,6 @@ import net.newpipe.newplayer.uiModel.UIModeState
 /** @hide */
 internal fun VideoPlayerUi(viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIState) {
     val activity = activity()
-
-    getEmbeddedUiConfig(activity = LocalContext.current as Activity)
 
     val exoPlayer by viewModel.newPlayer?.exoPlayer!!.collectAsState()
 

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/BottomUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/BottomUI.kt
@@ -130,10 +130,7 @@ internal fun BottomUI(
             ) {
                 Text(getTimeStringFromMs(uiState.durationInMs, getLocale() ?: locale))
 
-                val embeddedUiConfig = when (LocalContext.current) {
-                    is Activity -> getEmbeddedUiConfig(LocalContext.current as Activity)
-                    else -> EmbeddedUiConfig.DUMMY
-                }
+                val embeddedUiConfig = getEmbeddedUiConfig()
 
                 IconButton(
                     onClick = if (uiState.uiMode.fullscreen) {

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/Menu.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/Menu.kt
@@ -20,10 +20,8 @@
 
 package net.newpipe.newplayer.ui.videoplayer.controller
 
-import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Crop
@@ -34,7 +32,6 @@ import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.filled.PictureInPicture
 import androidx.compose.material.icons.filled.Share
 import androidx.compose.material.icons.filled.Subtitles
-import androidx.compose.material.icons.filled.Translate
 import androidx.compose.material.icons.filled.ZoomOutMap
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
@@ -58,11 +55,9 @@ import androidx.compose.ui.unit.DpOffset
 import androidx.compose.ui.unit.dp
 import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.R
-import net.newpipe.newplayer.logic.TrackUtils
 import net.newpipe.newplayer.ui.ContentScale
 import net.newpipe.newplayer.ui.common.LanguageMenu
 import net.newpipe.newplayer.ui.common.LanguageMenuItem
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -71,7 +66,6 @@ import net.newpipe.newplayer.ui.theme.VideoPlayerTheme
 import net.newpipe.newplayer.ui.videoplayer.pip.supportsPip
 import net.newpipe.newplayer.ui.common.getEmbeddedUiConfig
 import net.newpipe.newplayer.ui.common.showNotYetImplementedToast
-import java.util.Locale
 
 @OptIn(UnstableApi::class)
 @Composable
@@ -91,11 +85,7 @@ internal fun VideoPlayerMenu(
         mutableStateOf(0.dp)
     }
 
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
-
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
 
     Box {

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/TopUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/controller/TopUI.kt
@@ -20,7 +20,6 @@
 
 package net.newpipe.newplayer.ui.videoplayer.controller
 
-import android.app.Activity
 import android.widget.Toast
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
@@ -62,8 +61,6 @@ import androidx.compose.ui.unit.sp
 import androidx.media3.common.util.UnstableApi
 import net.newpipe.newplayer.R
 import net.newpipe.newplayer.data.VideoStreamTrack
-import net.newpipe.newplayer.logic.TrackUtils
-import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
 import net.newpipe.newplayer.uiModel.InternalNewPlayerViewModel
 import net.newpipe.newplayer.uiModel.NewPlayerViewModelDummy
@@ -80,12 +77,7 @@ import net.newpipe.newplayer.ui.common.showNotYetImplementedToast
 internal fun TopUI(
     modifier: Modifier, viewModel: InternalNewPlayerViewModel, uiState: NewPlayerUIState
 ) {
-    val embeddedUiConfig =
-        if (LocalContext.current is Activity)
-            getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-        else
-            EmbeddedUiConfig.DUMMY
-
+    val embeddedUiConfig = getEmbeddedUiConfig()
     Row(
         // the default height for an app bar is 64.dp according to this source:
         // https://cs.android.com/androidx/platform/frameworks/support/+/7b27816c561b8f271d79d24ab21ba7d08aaad031:compose/material3/material3/src/commonMain/kotlin/androidx/compose/material3/tokens/TopAppBarSmallTokens.kt;l=26

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/gesture_ui/EmbeddedGestureUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/gesture_ui/EmbeddedGestureUI.kt
@@ -66,10 +66,7 @@ internal fun EmbeddedGestureUI(
         mutableFloatStateOf(0f)
     }
 
-    val embeddedUiConfig = if (LocalContext.current is Activity)
-        getEmbeddedUiConfig(LocalContext.current as Activity)
-    else
-        EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
 
     val handleMovement = { movement: TouchedPosition ->
         //Log.d(TAG, "${movement.x}:${movement.y}")

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/gesture_ui/FullscreenGestureUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/videoplayer/gesture_ui/FullscreenGestureUI.kt
@@ -21,7 +21,6 @@
 
 package net.newpipe.newplayer.ui.videoplayer.gesture_ui
 
-import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.Spring
@@ -45,9 +44,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.onGloballyPositioned
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.media3.common.util.UnstableApi
+import net.newpipe.newplayer.ui.common.activity
 import net.newpipe.newplayer.uiModel.EmbeddedUiConfig
 import net.newpipe.newplayer.uiModel.UIModeState
 import net.newpipe.newplayer.uiModel.NewPlayerUIState
@@ -90,17 +89,10 @@ internal fun FullscreenGestureUI(
         mutableFloatStateOf(0f)
     }
 
-    val defaultBrightness =
-        if (LocalContext.current is Activity)
-            getDefaultBrightness(LocalContext.current as Activity)
-        else
-            0.5f
+    val defaultBrightness = activity(0.5f, { getDefaultBrightness() })
 
-    val embeddedUiConfig =
-        if (LocalContext.current is Activity)
-            getEmbeddedUiConfig(activity = LocalContext.current as Activity)
-        else
-            EmbeddedUiConfig.DUMMY
+    val embeddedUiConfig = getEmbeddedUiConfig()
+
 
     Box(modifier = modifier.onGloballyPositioned { coordinates ->
         heightPx = coordinates.size.height.toFloat()

--- a/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModel.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModel.kt
@@ -1,5 +1,6 @@
 package net.newpipe.newplayer.uiModel
 
+import android.app.Activity
 import androidx.annotation.OptIn
 import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.flow.SharedFlow

--- a/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModelDummy.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModelDummy.kt
@@ -1,5 +1,6 @@
 package net.newpipe.newplayer.uiModel
 
+import android.app.Activity
 import android.os.Bundle
 import androidx.media3.common.util.UnstableApi
 import kotlinx.coroutines.flow.MutableSharedFlow


### PR DESCRIPTION
When adding NewPlayer to NewPipe, we call it from a Fragment, which will not have a direct Activity in Context, but a wrapper class. We already had a function for that but did not call it everywhere. This fixes that.

We should probably assume we can find an Activity everywhere in the player UI. Later.

Also adds two minor changes.