### PR TITLE
StreamTrack: implement sorting as Comparator

### DIFF
--- a/new-player/src/main/java/net/newpipe/newplayer/logic/TrackUtils.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/logic/TrackUtils.kt
@@ -45,7 +45,7 @@ internal fun getAllAvailableTracksNonDuplicated(streams: List<Stream>): List<Str
         streams.forEach {
             totalList.addAll(it.streamTracks)
         }
-        totalList.sort()
+        totalList.sortWith(StreamTrack.Companion::compareResolution)
         return totalList.distinct()
     }
 
@@ -251,7 +251,7 @@ internal fun streamTracksFromMedia3Tracks(
                 }
             }
         }
-        tracks.sort()
+        tracks.sortWith(StreamTrack.Companion::compareResolution)
 
         return tracks.distinct()
     }


### PR DESCRIPTION
If we put the sorting into a `Comparator` functional interface function, we can implement multiple sort operations for these streams and it becomes a lot easier to compose them in interesting ways later.