### PR TITLE
NewPlayerUIState: correctly handle auto brightness

### DIFF
--- a/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/NewPlayerUI.kt
@@ -149,7 +149,7 @@ fun NewPlayerUI(
             val defaultBrightness = getDefaultBrightness(activity)
 
             setScreenBrightness(
-                uiState.brightness ?: defaultBrightness, activity
+                if (uiState.brightness < 0) defaultBrightness else uiState.brightness, activity
             )
         }
 

--- a/new-player/src/main/java/net/newpipe/newplayer/ui/common/utils.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/ui/common/utils.kt
@@ -72,7 +72,7 @@ internal fun LockScreenOrientation(orientation: Int) {
 internal fun getDefaultBrightness(activity: Activity): Float {
     val window = activity.window
     val layout = window.attributes as WindowManager.LayoutParams
-    return if (layout.screenBrightness < 0) 0.5f else layout.screenBrightness
+    return if (layout.screenBrightness < 0) -1f else layout.screenBrightness
 }
 
 @SuppressLint("NewApi")

--- a/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerUIState.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerUIState.kt
@@ -107,9 +107,9 @@ data class NewPlayerUIState(
     val soundVolume: Float,
 
     /**
-     * The brightness volume. Might be null if the system is in control of the brightness.
+     * The brightness volume. Might be negative if the system is in control of the brightness.
      */
-    val brightness: Float?,
+    val brightness: Float,
 
     /**
      * This is used to restore several values when switching back from a fullscreen view to an
@@ -212,7 +212,7 @@ data class NewPlayerUIState(
             playbackPositionInMs = 0,
             fastSeekSeconds = 0,
             soundVolume = 0f,
-            brightness = null,
+            brightness = -1f,
             embeddedUiConfig = null,
             playList = emptyList(),
             chapters = emptyList(),


### PR DESCRIPTION
Android system takes over the brightness controls when the value is negative as documented here: https://developer.android.com/reference/android/view/WindowManager.LayoutParams.html#screenBrightness

Update the documentation accordingly.