### PR TITLE
Use systemBrightness when brightness is set to default value

### DIFF
--- a/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModelImpl.kt
+++ b/new-player/src/main/java/net/newpipe/newplayer/uiModel/NewPlayerViewModelImpl.kt
@@ -590,8 +590,10 @@ class NewPlayerViewModelImpl @Inject constructor(
     override fun brightnessChange(changeRate: Float, systemBrightness: Float) {
         mutableUiState.update {
             if (it.uiMode.fullscreen) {
-                val currentBrightness = it.brightness
-                    ?: systemBrightness
+                val currentBrightness = when(val brightness = it.brightness) {
+                    -1f -> systemBrightness
+                    else -> brightness
+                }
                 Log.d(
                     TAG,
                     "currentBrightnes: $currentBrightness, sytemBrightness: $systemBrightness, changeRate: $changeRate"


### PR DESCRIPTION
This PR updates the brightnessChange function to use the systemBrighness when the the default value (-1) is set. This should also fix the failing test :D